### PR TITLE
Simplify zoom logic, add 256x384 crop option for DS games, fix FPS bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install SFML and the SFML-headers (libsfml-dev or similar) as well as libusb-1.0
 
 # How to use
 
-Start Cute3DSCapture. You can autoresize the window with 1-0 (1x, 1.5x, 2x,... original size). Press the spacebar to toggel window split.
+Start Cute3DSCapture. You can autoresize the window with 1-0 (1x, 1.5x, 2x,... original size). Press the spacebar to toggle window split. Press C to toggle cropping to the original DS resolution (hold START or SELECT when launching a game)
 
 If Cute3DSCapture doesn't detect your 3DS and you are using linux, copy 95-3dscapture.rules to /etc/udev/rules.d and reload udev-rules with ```udevadm control --reload-rules```.
 

--- a/main.cpp
+++ b/main.cpp
@@ -3,12 +3,35 @@ extern "C" {
     #include "3dscapture.h"
 }
 #include <SFML/Graphics.hpp>
+#include <bits/stdc++.h>
 
 static sf::Clock m_time;
 static uint frames;
 static bool split;
 static bool ds_crop_mode;
 static bool init;
+static std::map<int, int> keycode_zoom_map{
+    { sf::Keyboard::Num0, 10},
+    { sf::Keyboard::Num1, 1},
+    { sf::Keyboard::Num2, 2},
+    { sf::Keyboard::Num3, 3},
+    { sf::Keyboard::Num4, 4},
+    { sf::Keyboard::Num5, 5},
+    { sf::Keyboard::Num6, 6},
+    { sf::Keyboard::Num7, 7},
+    { sf::Keyboard::Num8, 8},
+    { sf::Keyboard::Num9, 9},
+    { sf::Keyboard::Numpad0, 10},
+    { sf::Keyboard::Numpad1, 1},
+    { sf::Keyboard::Numpad2, 2},
+    { sf::Keyboard::Numpad3, 3},
+    { sf::Keyboard::Numpad4, 4},
+    { sf::Keyboard::Numpad5, 5},
+    { sf::Keyboard::Numpad6, 6},
+    { sf::Keyboard::Numpad7, 7},
+    { sf::Keyboard::Numpad8, 8},
+    { sf::Keyboard::Numpad9, 9}
+};
 
 void toRGBA(const uint8_t* rgb, uint8_t* rgba, const size_t count) {
     size_t i;
@@ -117,37 +140,41 @@ int main()
                 window.close();
                 break;
             case sf::Event::KeyPressed:
-                switch(event.key.code) {
-                case sf::Keyboard::Num1:
-                    window.setSize(sf::Vector2u(400, 240*(2-int(split))));
-                    break;
-                case sf::Keyboard::Num2:
-                    window.setSize(sf::Vector2u(600, 360*(2-int(split))));
-                    break;
-                case sf::Keyboard::Num3:
-                    window.setSize(sf::Vector2u(800, 480*(2-int(split))));
-                    break;
-                case sf::Keyboard::Num4:
-                    window.setSize(sf::Vector2u(1000, 600*(2-int(split))));
-                    break;
-                case sf::Keyboard::Num5:
-                    window.setSize(sf::Vector2u(1200, 720*(2-int(split))));
-                    break;
-                case sf::Keyboard::Num6:
-                    window.setSize(sf::Vector2u(1400, 840*(2-int(split))));
-                    break;
-                case sf::Keyboard::Num7:
-                    window.setSize(sf::Vector2u(1600, 960*(2-int(split))));
-                    break;
-                case sf::Keyboard::Num8:
-                    window.setSize(sf::Vector2u(1800, 1080*(2-int(split))));
-                    break;
-                case sf::Keyboard::Num9:
-                    window.setSize(sf::Vector2u(2000, 1200*(2-int(split))));
-                    break;
-                case sf::Keyboard::Num0:
-                    window.setSize(sf::Vector2u(2200, 1320*(2-int(split))));
-                    break;
+                switch(event.key.code) {    
+                    case sf::Keyboard::Num1:
+                    case sf::Keyboard::Num2:
+                    case sf::Keyboard::Num3:
+                    case sf::Keyboard::Num4:
+                    case sf::Keyboard::Num5:
+                    case sf::Keyboard::Num6:
+                    case sf::Keyboard::Num7:
+                    case sf::Keyboard::Num8:
+                    case sf::Keyboard::Num9:
+                    case sf::Keyboard::Num0:
+                    case sf::Keyboard::Numpad1:
+                    case sf::Keyboard::Numpad2:
+                    case sf::Keyboard::Numpad3:
+                    case sf::Keyboard::Numpad4:
+                    case sf::Keyboard::Numpad5:
+                    case sf::Keyboard::Numpad6:
+                    case sf::Keyboard::Numpad7:
+                    case sf::Keyboard::Numpad8:
+                    case sf::Keyboard::Numpad9:
+                    case sf::Keyboard::Numpad0:
+                    // Zoom adjustment when top or main window is focused
+                        if (!ds_crop_mode) {
+                            window.setSize(sf::Vector2u(
+                                (200 * keycode_zoom_map[event.key.code] + 200),
+                                (3 * (200 * keycode_zoom_map[event.key.code] + 200) / 5) * (2-int(split))
+                            ));
+                        } else {
+                            window.setSize(sf::Vector2u(
+                                (128 * keycode_zoom_map[event.key.code] + 128),
+                                (3 * (128 * keycode_zoom_map[event.key.code] + 128) / 4) * (2-int(split))
+                            ));
+                        }
+                    
+                        break;
                 case sf::Keyboard::C:
                 // Switch to/from crop mode
                 if (!ds_crop_mode) {
@@ -227,34 +254,38 @@ int main()
                 case sf::Event::KeyPressed:
                     switch(event.key.code) {
                     case sf::Keyboard::Num1:
-                        bottom_window.setSize(sf::Vector2u(320, 240));
-                        break;
                     case sf::Keyboard::Num2:
-                        bottom_window.setSize(sf::Vector2u(480, 360));
-                        break;
                     case sf::Keyboard::Num3:
-                        bottom_window.setSize(sf::Vector2u(640, 480));
-                        break;
                     case sf::Keyboard::Num4:
-                        bottom_window.setSize(sf::Vector2u(800, 600));
-                        break;
                     case sf::Keyboard::Num5:
-                        bottom_window.setSize(sf::Vector2u(960, 720));
-                        break;
                     case sf::Keyboard::Num6:
-                        bottom_window.setSize(sf::Vector2u(1120, 840));
-                        break;
                     case sf::Keyboard::Num7:
-                        bottom_window.setSize(sf::Vector2u(1280, 960));
-                        break;
                     case sf::Keyboard::Num8:
-                        bottom_window.setSize(sf::Vector2u(1440, 1080));
-                        break;
                     case sf::Keyboard::Num9:
-                        bottom_window.setSize(sf::Vector2u(1600, 1200));
-                        break;
                     case sf::Keyboard::Num0:
-                        bottom_window.setSize(sf::Vector2u(1760, 1320));
+                    case sf::Keyboard::Numpad1:
+                    case sf::Keyboard::Numpad2:
+                    case sf::Keyboard::Numpad3:
+                    case sf::Keyboard::Numpad4:
+                    case sf::Keyboard::Numpad5:
+                    case sf::Keyboard::Numpad6:
+                    case sf::Keyboard::Numpad7:
+                    case sf::Keyboard::Numpad8:
+                    case sf::Keyboard::Numpad9:
+                    case sf::Keyboard::Numpad0:
+                    // Zoom adjustment when bottom window is focused
+                        if (!ds_crop_mode) {
+                            bottom_window.setSize(sf::Vector2u(
+                                (160 * keycode_zoom_map[event.key.code] + 160),
+                                (3 * (160 * keycode_zoom_map[event.key.code] + 160) / 4)
+                            ));
+                        } else {
+                            bottom_window.setSize(sf::Vector2u(
+                                (128 * keycode_zoom_map[event.key.code] + 128),
+                                (3 * (128 * keycode_zoom_map[event.key.code] + 128) / 4) * (2-int(split))
+                            ));
+                        }
+                    
                         break;
                     case sf::Keyboard::C:
                         if (!ds_crop_mode) {
@@ -379,5 +410,3 @@ int main()
     capture_deinit();
     return 0;
 }
-
-

--- a/main.cpp
+++ b/main.cpp
@@ -182,28 +182,26 @@ int main()
                     if (!split) {
                         window.setView(ds_crop_combined);
                         window.setSize(sf::Vector2u(256, 384));
-                        ds_crop_mode = true;
                     } else {
                         window.setView(ds_crop_top);
                         window.setSize(sf::Vector2u(256, 192));
                         bottom_window.create(sf::VideoMode(256, 192), "Bottom Screen Cute 3DS Capture");
                         bottom_window.setIcon(sfml_icon.width, sfml_icon.height, sfml_icon.pixel_data);
                         bottom_window.setView(ds_crop_bottom);
-                        ds_crop_mode = true;
                     }
+                    ds_crop_mode = true;
                 } else {
                     if (!split) {
                         window.setView(total);
                         window.setSize(sf::Vector2u(400, 480));
-                        ds_crop_mode = false;
                     } else {
                         window.setView(top);
                         window.setSize(sf::Vector2u(400, 240));
                         bottom_window.create(sf::VideoMode(320, 240), "Bottom Screen Cute 3DS Capture");
                         bottom_window.setIcon(sfml_icon.width, sfml_icon.height, sfml_icon.pixel_data);
                         bottom_window.setView(bottom);
-                        ds_crop_mode = false;
                     }
+                    ds_crop_mode = false;
                 }
                     break;
                  case sf::Keyboard::Space:
@@ -293,28 +291,26 @@ int main()
                             if (!split) {
                                 window.setView(ds_crop_combined);
                                 window.setSize(sf::Vector2u(256, 384));
-                                ds_crop_mode = true;
                             } else {
                                 window.setView(ds_crop_top);
                                 window.setSize(sf::Vector2u(256, 192));
                                 bottom_window.create(sf::VideoMode(256, 192), "Bottom Screen Cute 3DS Capture");
                                 bottom_window.setIcon(sfml_icon.width, sfml_icon.height, sfml_icon.pixel_data);
                                 bottom_window.setView(ds_crop_bottom);
-                                ds_crop_mode = true;
                             }
+                            ds_crop_mode = true;
                         } else {
                             if (!split) {
                                 window.setView(total);
                                 window.setSize(sf::Vector2u(400, 480));
-                                ds_crop_mode = false;
                             } else {
                                 window.setView(top);
                                 window.setSize(sf::Vector2u(400, 240));
                                 bottom_window.create(sf::VideoMode(320, 240), "Bottom Screen Cute 3DS Capture");
                                 bottom_window.setIcon(sfml_icon.width, sfml_icon.height, sfml_icon.pixel_data);
                                 bottom_window.setView(bottom);
-                                ds_crop_mode = false;
                             }
+                            ds_crop_mode = false;
                         }
                         break;
                     case sf::Keyboard::Space:

--- a/main.cpp
+++ b/main.cpp
@@ -101,6 +101,7 @@ int main()
     m_time = sf::Clock();
     sf::RenderWindow window(sf::VideoMode(400, 480), "Cute 3DS Capture");
     window.setIcon(sfml_icon.width,  sfml_icon.height,  sfml_icon.pixel_data);
+    window.setFramerateLimit(60);
     sf::RenderWindow bottom_window;
     sf::RectangleShape top_screen(sf::Vector2f(240,400));
     top_screen.rotate(-90);

--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,7 @@ extern "C" {
 static sf::Clock m_time;
 static uint frames;
 static bool split;
+static bool ds_crop_mode;
 static bool init;
 
 void toRGBA(const uint8_t* rgb, uint8_t* rgba, const size_t count) {
@@ -72,10 +73,11 @@ int main()
 {
     init = capture_init();
     split = false;
+    ds_crop_mode = false;
     frames = 0;
     m_time = sf::Clock();
     sf::RenderWindow window(sf::VideoMode(400, 480), "Cute 3DS Capture");
-	window.setIcon(sfml_icon.width,  sfml_icon.height,  sfml_icon.pixel_data);
+    window.setIcon(sfml_icon.width,  sfml_icon.height,  sfml_icon.pixel_data);
     sf::RenderWindow bottom_window;
     sf::RectangleShape top_screen(sf::Vector2f(240,400));
     top_screen.rotate(-90);
@@ -87,6 +89,9 @@ int main()
     sf::View total = sf::View(sf::FloatRect(0, 0, 400, 480));
     sf::View top = sf::View(sf::FloatRect(0, 0, 400, 240));
     sf::View bottom = sf::View(sf::FloatRect(40, 240, 320, 240));
+    sf::View ds_crop_combined = sf::View(sf::FloatRect(72, 48, 256, 384));
+    sf::View ds_crop_top = sf::View(sf::FloatRect(72, 48, 256, 192));
+    sf::View ds_crop_bottom = sf::View(sf::FloatRect(72, 240, 256, 192));
 
 
     sf::Texture texture;
@@ -143,17 +148,60 @@ int main()
                 case sf::Keyboard::Num0:
                     window.setSize(sf::Vector2u(2200, 1320*(2-int(split))));
                     break;
-                case sf::Keyboard::Space:
+                case sf::Keyboard::C:
+                // Switch to/from crop mode
+                if (!ds_crop_mode) {
                     if (!split) {
+                        window.setView(ds_crop_combined);
+                        window.setSize(sf::Vector2u(256, 384));
+                        ds_crop_mode = true;
+                    } else {
+                        window.setView(ds_crop_top);
+                        window.setSize(sf::Vector2u(256, 192));
+                        bottom_window.create(sf::VideoMode(256, 192), "Bottom Screen Cute 3DS Capture");
+                        bottom_window.setIcon(sfml_icon.width, sfml_icon.height, sfml_icon.pixel_data);
+                        bottom_window.setView(ds_crop_bottom);
+                        ds_crop_mode = true;
+                    }
+                } else {
+                    if (!split) {
+                        window.setView(total);
+                        window.setSize(sf::Vector2u(400, 480));
+                        ds_crop_mode = false;
+                    } else {
                         window.setView(top);
                         window.setSize(sf::Vector2u(400, 240));
                         bottom_window.create(sf::VideoMode(320, 240), "Bottom Screen Cute 3DS Capture");
-						bottom_window.setIcon(sfml_icon.width,  sfml_icon.height,  sfml_icon.pixel_data);
+                        bottom_window.setIcon(sfml_icon.width, sfml_icon.height, sfml_icon.pixel_data);
                         bottom_window.setView(bottom);
+                        ds_crop_mode = false;
+                    }
+                }
+                    break;
+                 case sf::Keyboard::Space:
+                    if (!split) {
+                        if (!ds_crop_mode) {
+                            window.setView(top);
+                            window.setSize(sf::Vector2u(400, 240));
+                            bottom_window.create(sf::VideoMode(320, 240), "Bottom Screen Cute 3DS Capture");
+                            bottom_window.setIcon(sfml_icon.width, sfml_icon.height, sfml_icon.pixel_data);
+                            bottom_window.setView(bottom);
+                        } else {
+                            window.setView(ds_crop_top);
+                            window.setSize(sf::Vector2u(256, 192));
+                            bottom_window.create(sf::VideoMode(256, 192), "Bottom Screen Cute 3DS Capture");
+                            bottom_window.setIcon(sfml_icon.width, sfml_icon.height, sfml_icon.pixel_data);
+                            bottom_window.setView(ds_crop_bottom);
+                        }
                         split = true;
                     } else {
-                        window.setView(total);
-                        window.setSize(sf::Vector2u(400, 480));
+                        if (!ds_crop_mode) {
+                            window.setView(total);
+                            window.setSize(sf::Vector2u(400, 480));
+                        } else {
+                            window.setView(ds_crop_combined);
+                            window.setSize(sf::Vector2u(256, 384));
+                        }
                         bottom_window.close();
                         split = false;
                     }
@@ -208,16 +256,59 @@ int main()
                     case sf::Keyboard::Num0:
                         bottom_window.setSize(sf::Vector2u(1760, 1320));
                         break;
+                    case sf::Keyboard::C:
+                        if (!ds_crop_mode) {
+                            if (!split) {
+                                window.setView(ds_crop_combined);
+                                window.setSize(sf::Vector2u(256, 384));
+                                ds_crop_mode = true;
+                            } else {
+                                window.setView(ds_crop_top);
+                                window.setSize(sf::Vector2u(256, 192));
+                                bottom_window.create(sf::VideoMode(256, 192), "Bottom Screen Cute 3DS Capture");
+                                bottom_window.setIcon(sfml_icon.width, sfml_icon.height, sfml_icon.pixel_data);
+                                bottom_window.setView(ds_crop_bottom);
+                                ds_crop_mode = true;
+                            }
+                        } else {
+                            if (!split) {
+                                window.setView(total);
+                                window.setSize(sf::Vector2u(400, 480));
+                                ds_crop_mode = false;
+                            } else {
+                                window.setView(top);
+                                window.setSize(sf::Vector2u(400, 240));
+                                bottom_window.create(sf::VideoMode(320, 240), "Bottom Screen Cute 3DS Capture");
+                                bottom_window.setIcon(sfml_icon.width, sfml_icon.height, sfml_icon.pixel_data);
+                                bottom_window.setView(bottom);
+                                ds_crop_mode = false;
+                            }
+                        }
+                        break;
                     case sf::Keyboard::Space:
                         if (!split) {
-                            window.setView(top);
-                            window.setSize(sf::Vector2u(400, 240));
-                            bottom_window.create(sf::VideoMode(320, 240), "Bottom Screen Cute 3DS Capture");
-                            bottom_window.setView(bottom);
+                            if (!ds_crop_mode) {
+                                window.setView(top);
+                                window.setSize(sf::Vector2u(400, 240));
+                                bottom_window.create(sf::VideoMode(320, 240), "Bottom Screen Cute 3DS Capture");
+                                bottom_window.setIcon(sfml_icon.width, sfml_icon.height, sfml_icon.pixel_data);
+                                bottom_window.setView(bottom);
+                            } else {
+                                window.setView(ds_crop_top);
+                                window.setSize(sf::Vector2u(256, 192));
+                                bottom_window.create(sf::VideoMode(256, 192), "Bottom Screen Cute 3DS Capture");
+                                bottom_window.setIcon(sfml_icon.width, sfml_icon.height, sfml_icon.pixel_data);
+                                bottom_window.setView(ds_crop_bottom);
+                            }
                             split = true;
                         } else {
-                            window.setView(total);
-                            window.setSize(sf::Vector2u(400, 480));
+                            if (!ds_crop_mode) {
+                                window.setView(total);
+                                window.setSize(sf::Vector2u(400, 480));
+                            } else {
+                                window.setView(ds_crop_combined);
+                                window.setSize(sf::Vector2u(256, 384));
+                            }
                             bottom_window.close();
                             split = false;
                         }


### PR DESCRIPTION
Now you can press C to crop the window to 256x384 (works with split mode) when you've launched a game in "original resolution" mode.

https://en-americas-support.nintendo.com/app/answers/detail/a_id/179/~/how-to-play-nintendo-ds-and-dsi-games-in-their-original-resolution